### PR TITLE
Fixed test runner name in tests.

### DIFF
--- a/robot-tests/remoteapplications/connect_to_previously_started_application.txt
+++ b/robot-tests/remoteapplications/connect_to_previously_started_application.txt
@@ -5,7 +5,7 @@ Library         OperatingSystem
 Library         org.robotframework.remoteapplications.common.DataBasePaths
 
 *** Variables ***
-${RUNNER}  ${CURDIR}${/}..${/}..${/}run_tests.py
+${RUNNER}  ${CURDIR}${/}..${/}..${/}build.py test
 
 *** Test Cases ***
 Connect To Previously Started Application/Applications Using Start Application Keyword & Application Started Keyword


### PR DESCRIPTION
run_tests.py was renamed to build.py earlier
